### PR TITLE
EXER2 Adding the constructor + logging implementation.

### DIFF
--- a/src/main/java/org/kuali/kfs/coa/businessobject/ReportingCode.java
+++ b/src/main/java/org/kuali/kfs/coa/businessobject/ReportingCode.java
@@ -37,6 +37,13 @@ public class ReportingCode {
     private Chart chart;
     private Organization org;
     private ReportingCode reportingCodes;
+    
+    /**
+     * Creates new object and sets up logging
+     */
+    public ReportingCode(){
+    	LOG.log(Level.INFO, "An object of class "+getClass().getName()+" has been instantiated");
+    }
 
     /**
      * @return Returns the chartOfAccountsCode.


### PR DESCRIPTION
I fixed the bug where when you instantiate the object there is no message printed to log. Looks like issue was we didn't have default constructor.
